### PR TITLE
set up past/upcoming workshops pages

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -38,12 +38,12 @@ main:
   weight: 20
 - identifier: workshops-upcoming
   name: Upcoming Workshops
-  pageRef: "/workshops-upcoming/"
+  pageRef: "/workshops/workshops-upcoming/"
   parent: workshops
   weight: 10
 - identifier: workshops-past
   name: Past Workshops
-  pageRef: "/workshops-past/"
+  pageRef: "/workshops/workshops-past/"
   parent: workshops
   weight: 20
 

--- a/content/workshops/workshops-past.md
+++ b/content/workshops/workshops-past.md
@@ -1,0 +1,5 @@
+---
+title: Past Workshops
+layout: workshops
+data_source: https://feeds.carpentries.org/swc_past_workshops.json
+---

--- a/content/workshops/workshops-upcoming.md
+++ b/content/workshops/workshops-upcoming.md
@@ -1,0 +1,5 @@
+---
+title: Upcoming workshops
+layout: workshops
+data_source: https://feeds.carpentries.org/swc_upcoming_workshops.json
+---


### PR DESCRIPTION
Sets up past/upcoming workshops pages.  Note flags are not displaying, as noted in https://github.com/carpentries/carpentries-hugo-theme/issues/6