### PR TITLE
remove lesson program filter from workshops list

### DIFF
--- a/content/workshops/workshops-past.md
+++ b/content/workshops/workshops-past.md
@@ -2,4 +2,5 @@
 title: Past Workshops
 layout: workshops
 data_source: https://feeds.carpentries.org/swc_past_workshops.json
+lesson_program: 'SWC'
 ---

--- a/content/workshops/workshops-upcoming.md
+++ b/content/workshops/workshops-upcoming.md
@@ -2,4 +2,5 @@
 title: Upcoming workshops
 layout: workshops
 data_source: https://feeds.carpentries.org/swc_upcoming_workshops.json
+lesson_program: 'SWC'
 ---


### PR DESCRIPTION
Removes (hides) the lesson program filter from the past/upcoming workshops list pages because this is a lesson program specific site.